### PR TITLE
Fix relative paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
 <body>
     <h1>Odin Recipes</h1>
     <ul>
-        <li><a href="/recipes/kenyan-beef-curry.html">Kenyan Beef Curry</a></li>
-        <li><a href="/recipes/kenyan-lyonnaise-potatoes.html">Kenyan Lyonnaise Potatoes</a></li>
-        <li><a href="/recipes/kenyan-beef-curry-simplified.html">Kenyan Beef Curry (Simplified)</a></li>
-        <li><a href="/recipes/omena-dry-fry.html">Omena Dry Fry</a></li>
+        <li><a href="recipes/kenyan-beef-curry.html">Kenyan Beef Curry</a></li>
+        <li><a href="recipes/kenyan-lyonnaise-potatoes.html">Kenyan Lyonnaise Potatoes</a></li>
+        <li><a href="recipes/kenyan-beef-curry-simplified.html">Kenyan Beef Curry (Simplified)</a></li>
+        <li><a href="recipes/omena-dry-fry.html">Omena Dry Fry</a></li>
     </ul>
 </body>
 </html>

--- a/recipes/kenyan-beef-curry-simplified.html
+++ b/recipes/kenyan-beef-curry-simplified.html
@@ -19,7 +19,7 @@
     <h1>Kenyan Beef Curry</h1>
 
     <figure>
-      <img src="/img/kenyan-beef-curry.jpg" alt="Tasty Kenyan Beef Curry" width="500" height="500"/>
+      <img src="../img/kenyan-beef-curry.jpg" alt="Tasty Kenyan Beef Curry" width="500" height="500"/>
       <figcaption>An image of some tasty Kenyan Beef Curry</figcaption>
     </figure>
 

--- a/recipes/kenyan-beef-curry.html
+++ b/recipes/kenyan-beef-curry.html
@@ -8,7 +8,7 @@
 <body>
     <a href="../index.html">Home</a>
     <h1>Kenyan Beef Curry</h1>
-    <img src="/img/kenyan-beef-curry.jpg" alt="Tasty Kenyan Beef Curry" width="500" height="500">
+    <img src="../img/kenyan-beef-curry.jpg" alt="Tasty Kenyan Beef Curry" width="500" height="500">
     <p>An image of some tasty Kenyan Beef Curry</p>
 
     <h2>Ingredients</h2>

--- a/recipes/kenyan-lyonnaise-potatoes.html
+++ b/recipes/kenyan-lyonnaise-potatoes.html
@@ -8,7 +8,7 @@
 <body>
     <a href="../index.html">Home</a>
     <h1>Kenyan Lyonnaise Potatoes</h1>
-    <img src="/img/Kenyan-Lyonnaise-Potatoes.jpg" alt="Tasty Kenyan Lyonnaise Potatoes" width="500" height="500">
+    <img src="../img/Kenyan-Lyonnaise-Potatoes.jpg" alt="Tasty Kenyan Lyonnaise Potatoes" width="500" height="500">
     <p>An image of some tasty Kenyan Lyonnaise Potatoes</p>
 
     <h2>Ingredients</h2>

--- a/recipes/omena-dry-fry.html
+++ b/recipes/omena-dry-fry.html
@@ -8,7 +8,7 @@
 <body>  
     <a href="../index.html">Home</a>
     <h1>Omena Dry Fry</h1>
-    <img src="/img/omena-dry-fry.jpg" alt="Tasty Omena Dry Fry" width="500" height="500">
+    <img src="../img/omena-dry-fry.jpg" alt="Tasty Omena Dry Fry" width="500" height="500">
     <p>An image of some tasty Omena Dry Fry</p>
 
     <h2>Ingredients</h2>


### PR DESCRIPTION
## Summary
- make recipe links relative in `index.html`
- use relative paths for images in recipe pages

These changes ensure the site works when served from a project subpath on GitHub Pages.

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fa714f908832ea6008f5b828b3f79